### PR TITLE
Adds a null check for skill decay for pawns w/o skills

### DIFF
--- a/Source/TinyTweaks/HarmonyPatches/Patch_SkillRecord.cs
+++ b/Source/TinyTweaks/HarmonyPatches/Patch_SkillRecord.cs
@@ -21,8 +21,9 @@ namespace TinyTweaks
 
             public static bool Prefix(SkillRecord __instance, Pawn ___pawn)
             {
+                CompSkillRecordCache cache = ___pawn.GetComp<CompSkillRecordCache>();
                 // Delay skill decay
-                if (TinyTweaksSettings.delayedSkillDecay && !___pawn.GetComp<CompSkillRecordCache>().CanDecaySkill(__instance.def))
+                if (TinyTweaksSettings.delayedSkillDecay && cache != null && !cache.CanDecaySkill(__instance.def))
                     return false;
                 return true;
             }


### PR DESCRIPTION
simple robots in Androids have no skills at all and the skills they do have don't ever decay